### PR TITLE
ci: fix publishment with given secret.GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-and-push-staged-images.yml
+++ b/.github/workflows/build-and-push-staged-images.yml
@@ -30,7 +30,8 @@ jobs:
     uses: ./.github/workflows/workflow-call-build-staged-images-push.yml
     with:
       image_group: all
-      ghcr_token: ${{ github.token }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   publish_manifests:
     name: Publish multi-arch manifests
@@ -42,4 +43,5 @@ jobs:
     uses: ./.github/workflows/workflow-call-publish-staged-manifests.yml
     with:
       tags: '["kbs","kbs-grpc-as","coco-as-grpc","coco-as-restful","rvps","kbs-client-image"]'
-      ghcr_token: ${{ github.token }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-call-build-staged-images-push.yml
+++ b/.github/workflows/workflow-call-build-staged-images-push.yml
@@ -8,9 +8,9 @@ on:
         type: string
         required: false
         default: all
+    secrets:
       ghcr_token:
         description: "Token for GHCR push"
-        type: string
         required: true
 
 permissions: {}
@@ -91,7 +91,7 @@ jobs:
       - name: Build ${{ matrix.tag }}
         uses: ./.github/actions/build-single-image
         with:
-          ghcr_token: ${{ inputs.ghcr_token }}
+          ghcr_token: ${{ secrets.ghcr_token }}
           docker_file: ${{ matrix.docker_file }}
           tag: ${{ matrix.tag }}
           platform: ${{ matrix.platform }}
@@ -153,7 +153,7 @@ jobs:
       - name: Build ${{ matrix.tag }}
         uses: ./.github/actions/build-single-image
         with:
-          ghcr_token: ${{ inputs.ghcr_token }}
+          ghcr_token: ${{ secrets.ghcr_token }}
           docker_file: ${{ matrix.docker_file }}
           tag: ${{ matrix.tag }}
           platform: ${{ matrix.platform }}
@@ -196,7 +196,7 @@ jobs:
       - name: Build ${{ matrix.tag }}
         uses: ./.github/actions/build-single-image
         with:
-          ghcr_token: ${{ inputs.ghcr_token }}
+          ghcr_token: ${{ secrets.ghcr_token }}
           docker_file: ${{ matrix.docker_file }}
           tag: ${{ matrix.tag }}
           platform: ${{ matrix.platform }}
@@ -230,7 +230,7 @@ jobs:
       - name: Build ${{ matrix.tag }}
         uses: ./.github/actions/build-single-image
         with:
-          ghcr_token: ${{ inputs.ghcr_token }}
+          ghcr_token: ${{ secrets.ghcr_token }}
           docker_file: ${{ matrix.docker_file }}
           tag: ${{ matrix.tag }}
           push: true

--- a/.github/workflows/workflow-call-publish-staged-manifests.yml
+++ b/.github/workflows/workflow-call-publish-staged-manifests.yml
@@ -12,9 +12,9 @@ on:
         type: string
         required: false
         default: '["x86_64","aarch64","s390x"]'
+    secrets:
       ghcr_token:
         description: "Token for GHCR push"
-        type: string
         required: true
 
 permissions: {}
@@ -37,7 +37,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ inputs.ghcr_token }}
+          password: ${{ secrets.ghcr_token }}
 
       - name: Publish multi-arch manifest
         shell: bash


### PR DESCRIPTION
We need to explicitly give the secret.GITHUB_TOKEN to publish artifacts.